### PR TITLE
Do not use POST fields for webhooks.

### DIFF
--- a/src/crest.php
+++ b/src/crest.php
@@ -97,6 +97,11 @@
 				}
 
 				$sPostFields = http_build_query($arParams[ 'params' ]);
+				if($arSettings[ 'is_web_hook' ] == 'Y')
+				{
+					$url =$url.'?'.$sPostFields;
+					$sPostFields=false;
+				}
 
 				try
 				{


### PR DESCRIPTION
Do not use POST fields for webhooks. This is not supported now. Use URL parameters