### PR TITLE
Update crest.php add error name

### DIFF
--- a/src/crest.php
+++ b/src/crest.php
@@ -152,7 +152,8 @@
 								'QUERY_LIMIT_EXCEEDED'   => 'Too many requests, maximum 2 query by second',
 								'ERROR_METHOD_NOT_FOUND' => 'Method not found! You can see the permissions of the application: CRest::call(\'scope\')',
 								'NO_AUTH_FOUND'          => 'Some setup error b24, check in table "b_module_to_module" event "OnRestCheckAuth"',
-								'INTERNAL_SERVER_ERROR'  => 'Server down, try later'
+								'INTERNAL_SERVER_ERROR'  => 'Server down, try later',
+								'CONNECTION_ERROR'       => 'Error connecting to authorization server'
 							];
 							if(!empty($arErrorInform[ $result[ 'error' ] ]))
 							{


### PR DESCRIPTION
Данный тип ошибки встречается эпизодически, происходит когда сервер авторизации Битрикс24 отвечает ошибкой, портал при этом выдаёт код 401, так как не может подтвердить права доступа. Вероятно пользователи данного SDK захотят обработать эту ошибку у себя в приложении.